### PR TITLE
Made regex able to parse both paths and firestore ref paths

### DIFF
--- a/langs/go/go.go
+++ b/langs/go/go.go
@@ -104,18 +104,20 @@ func (m *GoModeler) writeModel(model *firemodel.SchemaModel, sourceCoder firemod
 		f.Var().Id(fmt.Sprint(model.Name, "RegexPath")).Op("=").Qual("regexp", "MustCompile").CallFunc(func(g *jen.Group) {
 			regex := format
 			regex = regexp.QuoteMeta(regex)
-			g.Lit(fmt.Sprint("^", strings.Replace(format, "%s", "([a-zA-Z0-9]+)", -1), "$"))
+			start := "(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?"
+			g.Lit(fmt.Sprint(start, strings.Replace(format, "%s", "([a-zA-Z0-9]+)", -1)))
 		})
 
 		f.Commentf("%s is a named regex that can be use to filter out firestore events of %s", fmt.Sprint(model.Name, "RegexNamedPath"), model.Name)
 		f.Var().Id(fmt.Sprint(model.Name, "RegexNamedPath")).Op("=").Qual("regexp", "MustCompile").CallFunc(func(g *jen.Group) {
 			regex := format
 			regex = regexp.QuoteMeta(regex)
+			start := "(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?"
 			for _, arg := range args {
 				repl := fmt.Sprint("(?P<", arg, ">[a-zA-Z0-9]+)")
 				regex = strings.Replace(regex, "%s", repl, 1)
 			}
-			g.Lit(fmt.Sprint("^", regex, "$"))
+			g.Lit(fmt.Sprint(start, regex))
 		})
 
 		pathStructName := fmt.Sprint(model.Name, "PathStruct")

--- a/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
@@ -66,10 +66,10 @@ func TestModelPath(userId string, testModelId string) string {
 }
 
 // TestModelRegexPath is a regex that can be use to filter out firestore events of TestModel
-var TestModelRegexPath = regexp.MustCompile("^users/([a-zA-Z0-9]+)/test_models/([a-zA-Z0-9]+)$")
+var TestModelRegexPath = regexp.MustCompile("(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?users/([a-zA-Z0-9]+)/test_models/([a-zA-Z0-9]+)")
 
 // TestModelRegexNamedPath is a named regex that can be use to filter out firestore events of TestModel
-var TestModelRegexNamedPath = regexp.MustCompile("^users/(?P<user_id>[a-zA-Z0-9]+)/test_models/(?P<test_model_id>[a-zA-Z0-9]+)$")
+var TestModelRegexNamedPath = regexp.MustCompile("(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?users/(?P<user_id>[a-zA-Z0-9]+)/test_models/(?P<test_model_id>[a-zA-Z0-9]+)")
 
 // TestModelPathStruct is a struct that contains parts of a path of TestModel
 type TestModelPathStruct struct {

--- a/testfixtures/firemodel/TestFiremodelFromSchema/go/test_timestamps.firemodel.go
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/go/test_timestamps.firemodel.go
@@ -25,10 +25,10 @@ func TestTimestampsPath(testTimestampsId string) string {
 }
 
 // TestTimestampsRegexPath is a regex that can be use to filter out firestore events of TestTimestamps
-var TestTimestampsRegexPath = regexp.MustCompile("^timestamps/([a-zA-Z0-9]+)$")
+var TestTimestampsRegexPath = regexp.MustCompile("(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?timestamps/([a-zA-Z0-9]+)")
 
 // TestTimestampsRegexNamedPath is a named regex that can be use to filter out firestore events of TestTimestamps
-var TestTimestampsRegexNamedPath = regexp.MustCompile("^timestamps/(?P<test_timestamps_id>[a-zA-Z0-9]+)$")
+var TestTimestampsRegexNamedPath = regexp.MustCompile("(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?timestamps/(?P<test_timestamps_id>[a-zA-Z0-9]+)")
 
 // TestTimestampsPathStruct is a struct that contains parts of a path of TestTimestamps
 type TestTimestampsPathStruct struct {


### PR DESCRIPTION
Firestore reference paths have the database and project qualifier in them, however the Golang Firestore module doesn't allow you to reference documents like this. 

An optional non-capturing regex was added to the path parsers to filter out these reference paths.