### PR TITLE
Fix bug in 0.21 where maps were converted to strings by accident

### DIFF
--- a/langs/ios/ios.go
+++ b/langs/ios/ios.go
@@ -391,7 +391,7 @@ extension {{.Name | toCamel}}: CustomDebugStringConvertible {
         case "{{.Name | toLowerCamel}}":
             self.{{.Name | toLowerCamel}} = (value as? [[String: Any]])?
                 .enumerated()
-                .map { {{.Type.T | toSwiftType false }}(id: "\($0.offset)", value: "\($0.element)") }
+                .map { {{.Type.T | toSwiftType false }}(id: "\($0.offset)", value: $0.element) }
         {{- end}}
         {{- range .Fields | filterFieldsStructsOnly}}
         case "{{.Name | toLowerCamel}}":


### PR DESCRIPTION
Remove extra parens around $0.element, which was making our dict a string.