### PR TITLE
Fix sub-array element ID's to be unique between arrays

### DIFF
--- a/firemodel.example.firemodel
+++ b/firemodel.example.firemodel
@@ -38,6 +38,7 @@ model TestModel {
   array<double> doubles;
   array<TestEnum> directions;
   array<TestStruct> models;
+  array<TestStruct> models2;
   array<reference> refs;
   array<reference<TestTimestamps>> model_refs;
   map meta;

--- a/langs/ios/ios.go
+++ b/langs/ios/ios.go
@@ -283,7 +283,7 @@ override class var path: String { return "{{firestoreModelName . }}" }
         case "{{.Name | toLowerCamel}}":
             self.{{.Name | toLowerCamel}} = (value as? [[String: Any]])?
                 .enumerated()
-                .map { {{.Type.T | toSwiftType false }}(id: "\($0.offset)", value: $0.element) }
+                .map { {{.Type.T | toSwiftType false }}(id: "{{.Name | toLowerCamel}}.\($0.offset)", value: $0.element) }
         {{- end}}
         {{- range .Fields | filterFieldsStructsOnly}}
         case "{{.Name | toLowerCamel}}":

--- a/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
@@ -45,6 +45,8 @@ type TestModel struct {
 	Directions []TestEnum `firestore:"directions"`
 	// TODO: Add comment to TestModel.models.
 	Models []*TestStruct `firestore:"models"`
+	// TODO: Add comment to TestModel.models_2.
+	Models2 []*TestStruct `firestore:"models2"`
 	// TODO: Add comment to TestModel.refs.
 	Refs []*firestore.DocumentRef `firestore:"refs"`
 	// TODO: Add comment to TestModel.model_refs.

--- a/testfixtures/firemodel/TestFiremodelFromSchema/swift/Firemodel.swift
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/swift/Firemodel.swift
@@ -111,6 +111,8 @@ override class var path: String { return "test_models" }
     dynamic var directions: [TestEnum]?
     // TODO: Add documentation to models in firemodel schema.
     dynamic var models: [TestStruct]?
+    // TODO: Add documentation to models2 in firemodel schema.
+    dynamic var models2: [TestStruct]?
     // TODO: Add documentation to refs in firemodel schema.
     dynamic var refs: [Pring.AnyReference] = .init()
     // TODO: Add documentation to modelRefs in firemodel schema.
@@ -136,6 +138,8 @@ override class var path: String { return "test_models" }
             return self.direction?.firestoreValue
         case "models":
             return self.models?.map { $0.rawValue }
+        case "models2":
+            return self.models2?.map { $0.rawValue }
         case "nested":
             return self.nested?.rawValue
         default:
@@ -151,7 +155,11 @@ override class var path: String { return "test_models" }
         case "models":
             self.models = (value as? [[String: Any]])?
                 .enumerated()
-                .map { TestStruct(id: "\($0.offset)", value: $0.element) }
+                .map { TestStruct(id: "models.\($0.offset)", value: $0.element) }
+        case "models2":
+            self.models2 = (value as? [[String: Any]])?
+                .enumerated()
+                .map { TestStruct(id: "models2.\($0.offset)", value: $0.element) }
         case "nested":
           if let value = value as? [String: Any] {
             self.nested = TestStruct(id: "\(0)", value: value)

--- a/testfixtures/firemodel/TestFiremodelFromSchema/ts/firemodel.ts
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/ts/firemodel.ts
@@ -187,6 +187,8 @@ export namespace example {
     directions?: TestEnum[];
     /** TODO: Add documentation to models in firemodel schema. */
     models?: ITestStruct[];
+    /** TODO: Add documentation to models_2 in firemodel schema. */
+    models2?: ITestStruct[];
     /** TODO: Add documentation to refs in firemodel schema. */
     refs?: firestore.DocumentReference[];
     /** TODO: Add documentation to model_refs in firemodel schema. */


### PR DESCRIPTION
Use name of array in subelement indices to disambiguate between different arrays' items.