### PR TITLE
regex-bug

### DIFF
--- a/langs/go/go.go
+++ b/langs/go/go.go
@@ -154,19 +154,19 @@ func (m *GoModeler) writeModel(model *firemodel.SchemaModel, sourceCoder firemod
 		f.Commentf("%s is a regex that can be use to filter out firestore events of %s", fmt.Sprint(model.Name, "RegexPath"), model.Name)
 		f.Var().Id(fmt.Sprint(model.Name, "RegexPath")).Op("=").Qual("regexp", "MustCompile").CallFunc(func(g *jen.Group) {
 			regex := regexp.QuoteMeta(format)
-			start := "(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?"
-			g.Lit(fmt.Sprint(start, strings.Replace(regex, "%s", "([a-zA-Z0-9]+)", -1)))
+			start := "^(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?"
+			g.Lit(fmt.Sprint(start, strings.Replace(regex, "%s", "([a-zA-Z0-9]+)", -1), "$"))
 		})
 
 		f.Commentf("%s is a named regex that can be use to filter out firestore events of %s", fmt.Sprint(model.Name, "RegexNamedPath"), model.Name)
 		f.Var().Id(fmt.Sprint(model.Name, "RegexNamedPath")).Op("=").Qual("regexp", "MustCompile").CallFunc(func(g *jen.Group) {
 			regex := regexp.QuoteMeta(format)
-			start := "(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?"
+			start := "^(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?"
 			for _, arg := range args {
 				repl := fmt.Sprint("(?P<", arg, ">[a-zA-Z0-9]+)")
 				regex = strings.Replace(regex, "%s", repl, 1)
 			}
-			g.Lit(fmt.Sprint(start, regex))
+			g.Lit(fmt.Sprint(start, regex, "$"))
 		})
 
 		pathStructName := fmt.Sprint(model.Name, "PathStruct")

--- a/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/go/test_model.firemodel.go
@@ -68,10 +68,10 @@ func TestModelPath(userId string, testModelId string) string {
 }
 
 // TestModelRegexPath is a regex that can be use to filter out firestore events of TestModel
-var TestModelRegexPath = regexp.MustCompile("(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?users/([a-zA-Z0-9]+)/test_models/([a-zA-Z0-9]+)")
+var TestModelRegexPath = regexp.MustCompile("^(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?users/([a-zA-Z0-9]+)/test_models/([a-zA-Z0-9]+)$")
 
 // TestModelRegexNamedPath is a named regex that can be use to filter out firestore events of TestModel
-var TestModelRegexNamedPath = regexp.MustCompile("(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?users/(?P<user_id>[a-zA-Z0-9]+)/test_models/(?P<test_model_id>[a-zA-Z0-9]+)")
+var TestModelRegexNamedPath = regexp.MustCompile("^(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?users/(?P<user_id>[a-zA-Z0-9]+)/test_models/(?P<test_model_id>[a-zA-Z0-9]+)$")
 
 // TestModelPathStruct is a struct that contains parts of a path of TestModel
 type TestModelPathStruct struct {

--- a/testfixtures/firemodel/TestFiremodelFromSchema/go/test_timestamps.firemodel.go
+++ b/testfixtures/firemodel/TestFiremodelFromSchema/go/test_timestamps.firemodel.go
@@ -28,10 +28,10 @@ func TestTimestampsPath(testTimestampsId string) string {
 }
 
 // TestTimestampsRegexPath is a regex that can be use to filter out firestore events of TestTimestamps
-var TestTimestampsRegexPath = regexp.MustCompile("(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?timestamps/([a-zA-Z0-9]+)")
+var TestTimestampsRegexPath = regexp.MustCompile("^(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?timestamps/([a-zA-Z0-9]+)$")
 
 // TestTimestampsRegexNamedPath is a named regex that can be use to filter out firestore events of TestTimestamps
-var TestTimestampsRegexNamedPath = regexp.MustCompile("(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?timestamps/(?P<test_timestamps_id>[a-zA-Z0-9]+)")
+var TestTimestampsRegexNamedPath = regexp.MustCompile("^(?:projects/[^/]*/databases/[^/]*/documents/)?(?:/)?timestamps/(?P<test_timestamps_id>[a-zA-Z0-9]+)$")
 
 // TestTimestampsPathStruct is a struct that contains parts of a path of TestTimestamps
 type TestTimestampsPathStruct struct {

--- a/testfixtures/fixtures_test.go
+++ b/testfixtures/fixtures_test.go
@@ -13,15 +13,16 @@ func TestRegexPath(t *testing.T) {
 		exp  bool
 	}{
 		{"empty", "", false},
-		{"fully qualified", "/projects/some-project/databases/(default)/documents/users/123/test_models/abc", true},
-		{"doc only", "/users/123/test_models/abc", true},
-		{"fully qualified no leading slash", "projects/some-project/databases/(default)/documents/users/123/test_models/abc", true},
-		{"doc only no leading slash", "users/123/test_models/abc", true},
+		{"fully qualified", "projects/some-project/databases/(default)/documents/users/123/test_models/abc", true},
+		{"doc only", "users/123/test_models/abc", true},
+		{"doc only leading slash", "/users/123/test_models/abc", true},
 
 		{"prefix match, not real match", "users/123", false},
 		{"prefix match, not real match", "/users/123", false},
 		{"prefix match, not real match", "/users/123/", false},
 		{"prefix match, not real match", "users/123/", false},
+
+		{"root match, not real match", "users/123/test_models/abc/some-unrelated/child", false},
 
 		{"non match", "/othermodel/random", false},
 		{"roundtrip", firemodels.TestModelPath("userid", "testmodelid"), true},


### PR DESCRIPTION
Fix bug in generated regex. Patterns were accepting children collection paths because they were missing a `$`.